### PR TITLE
Add flexibility with clock dividers for mode 0 and 1

### DIFF
--- a/src/RTCZero.h
+++ b/src/RTCZero.h
@@ -38,46 +38,6 @@ public:
     MATCH_YYMMDDHHMMSS = RTC_MODE2_MASK_SEL_YYMMDDHHMMSS_Val  // Once, on a specific date and a specific time
   };
 
-  enum Prescaler: uint32_t // Same question as above applies
-  {
-    None = 0xffff,
-    MODE0_DIV1 = RTC_MODE0_CTRL_PRESCALER_DIV1,
-    MODE0_DIV2 = RTC_MODE0_CTRL_PRESCALER_DIV2,
-    MODE0_DIV4 = RTC_MODE0_CTRL_PRESCALER_DIV4,
-    MODE0_DIV8 = RTC_MODE0_CTRL_PRESCALER_DIV8,
-    MODE0_DIV16 = RTC_MODE0_CTRL_PRESCALER_DIV16,
-    MODE0_DIV32 = RTC_MODE0_CTRL_PRESCALER_DIV32,
-    MODE0_DIV64 = RTC_MODE0_CTRL_PRESCALER_DIV64,
-    MODE0_DIV128 = RTC_MODE0_CTRL_PRESCALER_DIV128,
-    MODE0_DIV256 = RTC_MODE0_CTRL_PRESCALER_DIV256,
-    MODE0_DIV512 = RTC_MODE0_CTRL_PRESCALER_DIV512,
-    MODE0_DIV1024 = RTC_MODE0_CTRL_PRESCALER_DIV1024,
-
-    MODE1_DIV1 = RTC_MODE1_CTRL_PRESCALER_DIV1,
-    MODE1_DIV2 = RTC_MODE1_CTRL_PRESCALER_DIV2,
-    MODE1_DIV4 = RTC_MODE1_CTRL_PRESCALER_DIV4,
-    MODE1_DIV8 = RTC_MODE1_CTRL_PRESCALER_DIV8,
-    MODE1_DIV16 = RTC_MODE1_CTRL_PRESCALER_DIV16,
-    MODE1_DIV32 = RTC_MODE1_CTRL_PRESCALER_DIV32,
-    MODE1_DIV64 = RTC_MODE1_CTRL_PRESCALER_DIV64,
-    MODE1_DIV128 = RTC_MODE1_CTRL_PRESCALER_DIV128,
-    MODE1_DIV256 = RTC_MODE1_CTRL_PRESCALER_DIV256,
-    MODE1_DIV512 = RTC_MODE1_CTRL_PRESCALER_DIV512,
-    MODE1_DIV1024 = RTC_MODE1_CTRL_PRESCALER_DIV1024,
-
-    MODE2_DIV1 = RTC_MODE2_CTRL_PRESCALER_DIV1,
-    MODE2_DIV2 = RTC_MODE2_CTRL_PRESCALER_DIV2,
-    MODE2_DIV4 = RTC_MODE2_CTRL_PRESCALER_DIV4,
-    MODE2_DIV8 = RTC_MODE2_CTRL_PRESCALER_DIV8,
-    MODE2_DIV16 = RTC_MODE2_CTRL_PRESCALER_DIV16,
-    MODE2_DIV32 = RTC_MODE2_CTRL_PRESCALER_DIV32,
-    MODE2_DIV64 = RTC_MODE2_CTRL_PRESCALER_DIV64,
-    MODE2_DIV128 = RTC_MODE2_CTRL_PRESCALER_DIV128,
-    MODE2_DIV256 = RTC_MODE2_CTRL_PRESCALER_DIV256,
-    MODE2_DIV512 = RTC_MODE2_CTRL_PRESCALER_DIV512,
-    MODE2_DIV1024 = RTC_MODE2_CTRL_PRESCALER_DIV1024
-  };
-
   enum Int_Source: uint8_t  // Helper to make interrupts simpler 
   {
     INT_COMP0 = 0,
@@ -88,7 +48,7 @@ public:
   };
 
   RTCZero();
-  void begin(bool resetTime = false, uint8_t rtc_mode = 2, bool clearOnMatch = false, Prescaler prescale = None);
+  void begin(bool resetTime = false, uint8_t rtc_mode = 2, bool clearOnMatch = false, uint32_t prescale = 32768);
 
   void enableAlarm(Alarm_Match match);
   void disableAlarm();
@@ -110,6 +70,8 @@ public:
   uint8_t getIntSource();
 
   uint32_t getCount();
+
+  uint32_t get_Prescaler() { return effective_prescaler; }
 
   uint32_t getCompare();
   uint16_t getCompare(uint8_t c);
@@ -171,9 +133,11 @@ public:
 
 private:
   bool _configured;
+  uint32_t effective_prescaler;
 
   void config32kOSC(void);
-  void configureClock(void);
+  void computeDivider(uint32_t prescale, uint32_t *rtc_prescale, uint32_t *gclk_prescale);
+  void configureClock(uint32_t gclk_div);
   void RTCreadRequest();
   bool RTCisSyncing(void);
   void RTCdisable();


### PR DESCRIPTION
Now the clock divider can get (close to) freely defined relative to base clock and is no longer fixed to 1024Hz clock rates.

Note that the possible divider values can be:
* a power of 2 
or:
* ([1:31] * 2^[0:10]) - so a divider of 24576 is also valid!

Signed-off-by: Martin Sperl <kernel@martin.sperl.org>